### PR TITLE
ivy: use specific idProduct for usb paths

### DIFF
--- a/aosp_e6553.mk
+++ b/aosp_e6553.mk
@@ -47,4 +47,4 @@ PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.sf.lcd_density=480 \
-    ro.usb.pid_suffix=1BA
+    ro.usb.pid_suffix=1C9


### PR DESCRIPTION
from 28.0.A.7.24

Signed-off-by: David Viteri davidteri91@gmail.com
