### PR TITLE
Update thermanager to support ivy's sensors

### DIFF
--- a/rootdir/system/etc/thermanager.xml
+++ b/rootdir/system/etc/thermanager.xml
@@ -1,19 +1,54 @@
 <thermanager>
 	<resources>
 		<!-- thermal zones -->
-		<resource name="zone0" type="tz">/sys/class/thermal/thermal_zone0</resource>
-		<resource name="zone1" type="tz">/sys/class/thermal/thermal_zone1</resource>
-		<resource name="zone2" type="tz">/sys/class/thermal/thermal_zone2</resource>
-		<resource name="zone3" type="tz">/sys/class/thermal/thermal_zone3</resource>
-		<resource name="zone4" type="tz">/sys/class/thermal/thermal_zone4</resource>
-		<resource name="zone5" type="tz">/sys/class/thermal/thermal_zone5</resource>
-		<resource name="zone6" type="tz">/sys/class/thermal/thermal_zone6</resource>
-		<resource name="zone7" type="tz">/sys/class/thermal/thermal_zone7</resource>
-		<resource name="zone8" type="tz">/sys/class/thermal/thermal_zone8</resource>
-		<resource name="zone9" type="tz">/sys/class/thermal/thermal_zone9</resource>
-		<resource name="zone10" type="tz">/sys/class/thermal/thermal_zone10</resource>
-		<resource name="zone11" type="tz">/sys/class/thermal/thermal_zone11</resource>
-		<resource name="zone12" type="tz">/sys/class/thermal/thermal_zone12</resource>
+		<resource name="tsens_tz_sensor0"  type="tz">/sys/class/thermal/thermal_zone3</resource>
+		<resource name="tsens_tz_sensor1"  type="tz">/sys/class/thermal/thermal_zone4</resource>
+		<resource name="tsens_tz_sensor2"  type="tz">/sys/class/thermal/thermal_zone5</resource>
+		<resource name="tsens_tz_sensor3"  type="tz">/sys/class/thermal/thermal_zone6</resource>
+		<resource name="tsens_tz_sensor4"  type="tz">/sys/class/thermal/thermal_zone7</resource>
+		<resource name="tsens_tz_sensor5"  type="tz">/sys/class/thermal/thermal_zone8</resource>
+
+		<resource name="tsens_tz_sensor6"  type="tz">/sys/class/thermal/thermal_zone9</resource>  <!-- cpu7 -->
+		<resource name="tsens_tz_sensor7"  type="tz">/sys/class/thermal/thermal_zone10</resource> <!-- cpu0 -->
+		<resource name="tsens_tz_sensor8"  type="tz">/sys/class/thermal/thermal_zone11</resource> <!-- cpu1 -->
+		<resource name="tsens_tz_sensor9"  type="tz">/sys/class/thermal/thermal_zone12</resource> <!-- cpu2 -->
+		<resource name="tsens_tz_sensor10" type="tz">/sys/class/thermal/thermal_zone13</resource> <!-- cpu3 -->
+		<resource name="tsens_tz_sensor11" type="tz">/sys/class/thermal/thermal_zone14</resource> <!-- gpu0 -->
+		<resource name="tsens_tz_sensor12" type="tz">/sys/class/thermal/thermal_zone15</resource> <!-- gpu1 -->
+		<resource name="tsens_tz_sensor13" type="tz">/sys/class/thermal/thermal_zone16</resource> <!-- cpu4 -->
+		<resource name="tsens_tz_sensor14" type="tz">/sys/class/thermal/thermal_zone17</resource> <!-- cpu5 -->
+		<resource name="tsens_tz_sensor15" type="tz">/sys/class/thermal/thermal_zone18</resource> <!-- cpu6 -->
+
+		<resource name="pm8994_tz" type="tz">/sys/class/thermal/thermal_zone19</resource>
+		<resource name="battery" type="tz">/sys/class/thermal/thermal_zone26</resource> <!-- same values as zone2, bms -->
+
+		<resource name="temp-core" type="union">
+			<resource name="tsens_tz_sensor0" />
+			<resource name="tsens_tz_sensor1" />
+			<resource name="tsens_tz_sensor2" />
+			<resource name="tsens_tz_sensor3" />
+			<resource name="tsens_tz_sensor4" />
+			<resource name="tsens_tz_sensor5" />
+		</resource>
+
+		<resource name="temp-cluster-a53" type="union">
+			<resource name="tsens_tz_sensor7"  />
+			<resource name="tsens_tz_sensor8"  />
+			<resource name="tsens_tz_sensor9"  />
+			<resource name="tsens_tz_sensor10" />
+		</resource>
+
+		<resource name="temp-cluster-a57" type="union">
+			<resource name="tsens_tz_sensor6"  />
+			<resource name="tsens_tz_sensor13" />
+			<resource name="tsens_tz_sensor14" />
+			<resource name="tsens_tz_sensor15" />
+		</resource>
+
+		<resource name="temp-gpu" type="union">
+			<resource name="tsens_tz_sensor11" />
+			<resource name="tsens_tz_sensor12" />
+		</resource>
 
 		<!-- generic cpufreq -->
 		<resource name="cpu0" type="sysfs">/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq</resource>
@@ -25,11 +60,14 @@
 		<resource name="cpu6" type="sysfs">/sys/devices/system/cpu/cpu6/cpufreq/scaling_max_freq</resource>
 		<resource name="cpu7" type="sysfs">/sys/devices/system/cpu/cpu7/cpufreq/scaling_max_freq</resource>
 
-		<resource name="cpu" type="union">
+		<resource name="cluster-a53" type="union">
 			<resource name="cpu0" />
 			<resource name="cpu1" />
 			<resource name="cpu2" />
 			<resource name="cpu3" />
+		</resource>
+
+		<resource name="cluster-a57" type="union">
 			<resource name="cpu4" />
 			<resource name="cpu5" />
 			<resource name="cpu6" />
@@ -38,27 +76,9 @@
 
 		<!-- device-specific -->
 		<resource name="backlight" type="sysfs">/sys/class/leds/lcd-backlight/max_brightness</resource>
-
-		<resource name="temp-emmc" type="msm-adc">/sys/devices/soc.0/00-vadc-3100/emmc_therm</resource>
-		<resource name="temp-batt" type="msm-adc">/sys/devices/soc.0/00-vadc-3100/msm_therm</resource>
 		<resource name="kgsl-3d0" type="sysfs">/sys/class/kgsl/kgsl-3d0/max_gpuclk</resource>
-		<resource name="dc" type="sysfs">/sys/class/power_supply/qpnp-dc/current_max</resource>
 		<resource name="usb" type="sysfs">/sys/class/power_supply/usb/current_max</resource>
-		<resource name="charger" type="sysfs">/sys/class/power_supply/battery/system_temp_level</resource>
-		<resource name="charge_en" type="sysfs">/sys/class/power_supply/battery/charging_enabled</resource>
-		<resource name="temp-core" type="alias" resource="zone2" />
-
-		<resource name="temp-gpu" type="union">
-			<resource name="zone9" />
-			<resource name="zone10" />
-		</resource>
-
-		<resource name="temp-cpu" type="union">
-			<resource name="zone5" />
-			<resource name="zone6" />
-			<resource name="zone7" />
-			<resource name="zone8" />
-		</resource>
+		<resource name="charging_enabled" type="sysfs">/sys/class/power_supply/battery/charging_enabled</resource>
 
 		<!-- TODO: -->
 		<resource name="camera" type="echo" />
@@ -77,19 +97,9 @@
 		<mitigation level="6"><value resource="usb">150000</value></mitigation>
 	</control>
 
-	<control name="dc">
-		<mitigation level="off"><value resource="dc">1800000</value></mitigation>
-		<mitigation level="1"><value resource="dc">1100000</value></mitigation>
-		<mitigation level="2"><value resource="dc">900000</value></mitigation>
-		<mitigation level="3"><value resource="dc">700000</value></mitigation>
-		<mitigation level="4"><value resource="dc">500000</value></mitigation>
-		<mitigation level="5"><value resource="dc">300000</value></mitigation>
-		<mitigation level="6"><value resource="dc">150000</value></mitigation>
-	</control>
-
-	<control name="charge_en">
-		<mitigation level="off"><value resource="charge_en">1</value></mitigation>
-		<mitigation level="1"><value resource="charge_en">0</value></mitigation>
+	<control name="battery_protect">
+		<mitigation level="off"><value resource="charging_enabled">1</value></mitigation>
+		<mitigation level="1"><value resource="charging_enabled">0</value></mitigation>
 		<mitigation level="2"><value resource="shutdown" /></mitigation>
 	</control>
 
@@ -104,6 +114,9 @@
 		<mitigation level="7"><value resource="charger">7</value></mitigation>
 		<mitigation level="8"><value resource="charger">8</value></mitigation>
 		<mitigation level="9"><value resource="charger">9</value></mitigation>
+		<mitigation level="10"><value resource="charger">10</value></mitigation>
+		<mitigation level="11"><value resource="charger">11</value></mitigation>
+		<mitigation level="12"><value resource="charger">12</value></mitigation>
 	</control>
 
 	<control name="modem">
@@ -124,38 +137,58 @@
 
 	<control name="backlight">
 		<mitigation level="off"><value resource="backlight">255</value></mitigation>
-		<mitigation level="1"><value resource="backlight">192</value></mitigation>
-		<mitigation level="2"><value resource="backlight">128</value></mitigation>
-		<mitigation level="3"><value resource="backlight">64</value></mitigation>
-		<mitigation level="4"><value resource="backlight">51</value></mitigation>
+		<mitigation level="1"><value resource="backlight">209</value></mitigation>
+		<mitigation level="2"><value resource="backlight">171</value></mitigation>
+		<mitigation level="3"><value resource="backlight">141</value></mitigation>
+		<mitigation level="4"><value resource="backlight">115</value></mitigation>
+		<mitigation level="5"><value resource="backlight">95</value></mitigation>
+		<mitigation level="6"><value resource="backlight">78</value></mitigation>
+		<mitigation level="7"><value resource="backlight">64</value></mitigation>
+		<mitigation level="8"><value resource="backlight">52</value></mitigation>
+		<mitigation level="9"><value resource="backlight">44</value></mitigation>
 	</control>
 
 	<control name="gpu">
-		<mitigation level="off"><value resource="gpu">578000000</value></mitigation>
-		<mitigation level="1"><value resource="gpu">462400000</value></mitigation>
-		<mitigation level="2"><value resource="gpu">389000000</value></mitigation>
-		<mitigation level="3"><value resource="gpu">330000000</value></mitigation>
-		<mitigation level="4"><value resource="gpu">200000000</value></mitigation>
-		<mitigation level="5"><value resource="shutdown" /></mitigation>
+		<mitigation level="off"><value resource="gpu">600000000</value></mitigation>
+		<mitigation level="1"><value resource="gpu">510000000</value></mitigation>
+		<mitigation level="2"><value resource="gpu">450000000</value></mitigation>
+		<mitigation level="3"><value resource="gpu">390000000</value></mitigation>
+		<mitigation level="4"><value resource="gpu">305000000</value></mitigation>
+		<mitigation level="5"><value resource="gpu">180000000</value></mitigation>
+		<mitigation level="6"><value resource="shutdown" /></mitigation>
 	</control>
 
-	<control name="cpu">
-		<mitigation level="off"><value resource="cpu">2457600</value></mitigation>
-		<mitigation level="1"><value resource="cpu">2265600</value></mitigation>
-		<mitigation level="2"><value resource="cpu">1958400</value></mitigation>
-		<mitigation level="3"><value resource="cpu">1728000</value></mitigation>
-		<mitigation level="4"><value resource="cpu">1574400</value></mitigation>
-		<mitigation level="5"><value resource="cpu">1497600</value></mitigation>
-		<mitigation level="6"><value resource="cpu">1267200</value></mitigation>
-		<mitigation level="7"><value resource="cpu">1190400</value></mitigation>
-		<mitigation level="8"><value resource="cpu">1036800</value></mitigation>
-		<mitigation level="9"><value resource="cpu">960000</value></mitigation>
-		<mitigation level="10"><value resource="cpu">883200</value></mitigation>
-		<mitigation level="11"><value resource="cpu">729600</value></mitigation>
-		<mitigation level="12"><value resource="cpu">652800</value></mitigation>
-		<mitigation level="13"><value resource="cpu">422400</value></mitigation>
-		<mitigation level="14"><value resource="cpu">300000</value></mitigation>
-		<mitigation level="15"><value resource="shutdown" /></mitigation>
+	<control name="cpu-a57">
+		<mitigation level="off"><value resource="cluster1">1958400</value></mitigation>
+		<mitigation level="1"><value resource="cluster1">1824000</value></mitigation>
+		<mitigation level="2"><value resource="cluster1">1728000</value></mitigation>
+		<mitigation level="3"><value resource="cluster1">1632000</value></mitigation>
+		<mitigation level="4"><value resource="cluster1">1536000</value></mitigation>
+		<mitigation level="5"><value resource="cluster1">1440000</value></mitigation>
+		<mitigation level="6"><value resource="cluster1">1344000</value></mitigation>
+		<mitigation level="7"><value resource="cluster1">1248000</value></mitigation>
+		<mitigation level="8"><value resource="cluster1">960000</value></mitigation>
+		<mitigation level="9"><value resource="cluster1">864000</value></mitigation>
+		<mitigation level="10"><value resource="cluster1">768000</value></mitigation>
+		<mitigation level="11"><value resource="cluster1">633600</value></mitigation>
+		<mitigation level="12"><value resource="cluster1">480000</value></mitigation>
+		<mitigation level="13"><value resource="cluster1">384000</value></mitigation>
+		<mitigation level="14"><value resource="shutdown" /></mitigation>
+	</control>
+
+	<control name="cpu-a53">
+		<mitigation level="off"><value resource="cluster1">1555200</value></mitigation>
+		<mitigation level="1"><value resource="cluster1">1478400</value></mitigation>
+		<mitigation level="2"><value resource="cluster1">1344000</value></mitigation>
+		<mitigation level="3"><value resource="cluster1">1248000</value></mitigation>
+		<mitigation level="4"><value resource="cluster1">960000</value></mitigation>
+		<mitigation level="5"><value resource="cluster1">864000</value></mitigation>
+		<mitigation level="6"><value resource="cluster1">768000</value></mitigation>
+		<mitigation level="7"><value resource="cluster1">672000</value></mitigation>
+		<mitigation level="8"><value resource="cluster1">600000</value></mitigation>
+		<mitigation level="9"><value resource="cluster1">460800</value></mitigation>
+		<mitigation level="10"><value resource="cluster1">384000</value></mitigation>
+		<mitigation level="11"><value resource="shutdown" /></mitigation>
 	</control>
 
 	<!-- burn-out protection -->
@@ -163,145 +196,210 @@
 		<threshold>
 			<mitigation name="shutdown" level="off" />
 		</threshold>
-		<threshold trigger="120" clear="115">
+		<threshold trigger="120" clear="100">
 			<mitigation name="shutdown" level="1" />
 		</threshold>
 	</configuration>
 
 	<!-- USB and DC -->
-	<configuration sensor="temp-emmc">
+	<configuration sensor="pm8994_tz">
 		<threshold>
-			<mitigation name="dc" level="off" />
 			<mitigation name="usb" level="off" />
 		</threshold>
-		<threshold trigger="384" clear="364">
-			<mitigation name="dc" level="1" />
+		<threshold trigger="58700" clear="57200">
 			<mitigation name="usb" level="1" />
 		</threshold>
-		<threshold trigger="400" clear="380">
-			<mitigation name="dc" level="2" />
+		<threshold trigger="61700" clear="58700">
 			<mitigation name="usb" level="2" />
 		</threshold>
-		<threshold trigger="416" clear="396">
-			<mitigation name="dc" level="3" />
+		<threshold trigger="63100" clear="61700">
 			<mitigation name="usb" level="3" />
 		</threshold>
-		<threshold trigger="424" clear="412">
-			<mitigation name="dc" level="4" />
+		<threshold trigger="64300" clear="63100">
 			<mitigation name="usb" level="4" />
 		</threshold>
-		<threshold trigger="432" clear="420">
-			<mitigation name="dc" level="5" />
+		<threshold trigger="65400" clear="64300">
 			<mitigation name="usb" level="5" />
 		</threshold>
-		<threshold trigger="448" clear="440">
-			<mitigation name="dc" level="6" />
+		<threshold trigger="66600" clear="65400">
 			<mitigation name="usb" level="6" />
 		</threshold>
 	</configuration>
 
 	<!-- charging -->
-	<configuration sensor="temp-emmc">
+	<configuration sensor="pm8994_tz">
 		<threshold>
 			<mitigation name="charging" level="off" />
 		</threshold>
-		<threshold trigger="384" clear="372">
-			<mitigation name="charging" level="2" />
+		<threshold trigger="47700" clear="43000">
+			<mitigation name="charging" level="3" />
 		</threshold>
-		<threshold trigger="400" clear="380">
-			<mitigation name="charging" level="4" />
-		</threshold>
-		<threshold trigger="416" clear="396">
-			<mitigation name="charging" level="6" />
-		</threshold>
-		<threshold trigger="432" clear="420">
-			<mitigation name="charging" level="7" />
-		</threshold>
-		<threshold trigger="448" clear="436">
+		<threshold trigger="52000" clear="51400">
 			<mitigation name="charging" level="8" />
 		</threshold>
+		<threshold trigger="53200" clear="52600">
+			<mitigation name="charging" level="9" />
+		</threshold>
+		<threshold trigger="53600" clear="53200">
+			<mitigation name="charging" level="12" />
+		</threshold>
 	</configuration>
-	<configuration sensor="temp-batt">
+
+	<configuration sensor="battery">
 		<threshold>
-			<mitigation name="charge_en" level="off" />
+			<mitigation name="battery_protect" level="off" />
 		</threshold>
-		<threshold trigger="464" clear="442">
-			<mitigation name="charge_en" level="1" />
+		<threshold trigger="40000" clear="38000">
+			<mitigation name="battery_protect" level="1" />
 		</threshold>
-		<threshold trigger="800" clear="780">
-			<mitigation name="charge_en" level="2" />
+		<threshold trigger="67000" clear="60000">
+			<mitigation name="battery_protect" level="2" />
 		</threshold>
 	</configuration>
 
 	<!-- GPU -->
-	<configuration sensor="temp-emmc">
+	<configuration sensor="pm8994_tz">
 		<threshold>
 			<mitigation name="gpu" level="off" />
 		</threshold>
-		<threshold trigger="464" clear="452">
-			<mitigation name="gpu" level="4" />
+		<threshold trigger="54000" clear="53600">
+			<mitigation name="gpu" level="2" />
 		</threshold>
-	</configuration>
-	<configuration sensor="temp-gpu">
-		<threshold>
-			<mitigation name="gpu" level="off" />
+		<threshold trigger="55000" clear="54500">
+			<mitigation name="gpu" level="3" />
 		</threshold>
-		<threshold trigger="100" clear="95">
-			<mitigation name="gpu" level="4" />
-		</threshold>
-		<threshold trigger="120" clear="110">
+		<threshold trigger="55900" clear="55500">
 			<mitigation name="gpu" level="5" />
 		</threshold>
 	</configuration>
 
 	<!-- modem -->
-	<configuration sensor="temp-emmc">
+	<configuration sensor="pm8994_tz">
 		<threshold>
 			<mitigation name="modem" level="off" />
 		</threshold>
-		<threshold trigger="464" clear="452">
+		<threshold trigger="55500" clear="55000">
 			<mitigation name="modem" level="1" />
 		</threshold>
 	</configuration>
 
 	<!-- backlight -->
-	<configuration sensor="temp-emmc">
+	<configuration sensor="pm8994_tz">
 		<threshold>
 			<mitigation name="backlight" level="off" />
 		</threshold>
-		<threshold trigger="424" clear="412">
+		<threshold trigger="47700" clear="43000">
 			<mitigation name="backlight" level="1" />
 		</threshold>
-		<threshold trigger="440" clear="428">
+		<threshold trigger="48900" clear="47700">
 			<mitigation name="backlight" level="2" />
 		</threshold>
-		<threshold trigger="456" clear="444">
+		<threshold trigger="50200" clear="48900">
 			<mitigation name="backlight" level="3" />
 		</threshold>
-		<threshold trigger="464" clear="452">
+		<threshold trigger="51400" clear="50200">
 			<mitigation name="backlight" level="4" />
+		</threshold>
+		<threshold trigger="52000" clear="51400">
+			<mitigation name="backlight" level="5" />
+		</threshold>
+		<threshold trigger="52600" clear="52000">
+			<mitigation name="backlight" level="6" />
+		</threshold>
+		<threshold trigger="53200" clear="52600">
+			<mitigation name="backlight" level="7" />
+		</threshold>
+		<threshold trigger="53600" clear="53200">
+			<mitigation name="backlight" level="8" />
+		</threshold>
+		<threshold trigger="54000" clear="53600">
+			<mitigation name="backlight" level="9" />
 		</threshold>
 	</configuration>
 
-	<!-- CPU -->
-	<configuration sensor="temp-cpu">
+	<!-- CPU A53 -->
+	<configuration sensor="pm8994_tz">
 		<threshold>
-			<mitigation name="cpu" level="off" />
+			<mitigation name="cpu-a53" level="off" />
 		</threshold>
-		<threshold trigger="80" clear="75">
-			<mitigation name="cpu" level="3" />
+		<threshold trigger="52600" clear="52000">
+			<mitigation name="cpu-a53" level="2" />
 		</threshold>
-		<threshold trigger="90" clear="85">
-			<mitigation name="cpu" level="5" />
+		<threshold trigger="53600" clear="53200">
+			<mitigation name="cpu-a53" level="4" />
 		</threshold>
-		<threshold trigger="95" clear="90">
-			<mitigation name="cpu" level="10" />
+		<threshold trigger="54500" clear="54000">
+			<mitigation name="cpu-a53" level="5" />
 		</threshold>
-		<threshold trigger="110" clear="95">
-			<mitigation name="cpu" level="13" />
+		<threshold trigger="55500" clear="55000">
+			<mitigation name="cpu-a53" level="6" />
 		</threshold>
-		<threshold trigger="120" clear="115">
-			<mitigation name="cpu" level="15" />
+		<threshold trigger="55900" clear="55500">
+			<mitigation name="cpu-a53" level="8" />
+		</threshold>
+		<threshold trigger="56300" clear="55900">
+			<mitigation name="cpu-a53" level="9" />
+		</threshold>
+		<threshold trigger="56800" clear="56300">
+			<mitigation name="cpu-a53" level="10" />
+		</threshold>
+	</configuration>
+
+	<configuration sensor="temp-cluster-a53">
+		<threshold>
+			<mitigation name="cpu-a53" level="off" />
+		</threshold>
+		<threshold trigger="75" clear="68">
+			<mitigation name="cpu-a53" level="2" />
+		</threshold>
+		<threshold trigger="78" clear="73">
+			<mitigation name="cpu-a53" level="4" />
+		</threshold>
+		<threshold trigger="120" clear="100">
+			<mitigation name="cpu-a53" level="11" />
+		</threshold>
+	</configuration>
+
+	<!-- CPU A57 -->
+	<configuration sensor="pm8994_tz">
+		<threshold>
+			<mitigation name="cpu-a57" level="off" />
+		</threshold>
+		<threshold trigger="48900" clear="47700">
+			<mitigation name="cpu-a57" level="2" />
+		</threshold>
+		<threshold trigger="50200" clear="48900">
+			<mitigation name="cpu-a57" level="4" />
+		</threshold>
+		<threshold trigger="51400" clear="50200">
+			<mitigation name="cpu-a57" level="7" />
+		</threshold>
+		<threshold trigger="52000" clear="51400">
+			<mitigation name="cpu-a57" level="10" />
+		</threshold>
+		<threshold trigger="52600" clear="52000">
+			<mitigation name="cpu-a57" level="11" />
+		</threshold>
+		<threshold trigger="53600" clear="53200">
+			<mitigation name="cpu-a57" level="12" />
+		</threshold>
+		<threshold trigger="54500" clear="54000">
+			<mitigation name="cpu-a57" level="13" />
+		</threshold>
+	</configuration>
+
+	<configuration sensor="temp-cluster-a57">
+		<threshold>
+			<mitigation name="cpu-a57" level="off" />
+		</threshold>
+		<threshold trigger="75" clear="68">
+			<mitigation name="cpu-a57" level="9" />
+		</threshold>
+		<threshold trigger="78" clear="73">
+			<mitigation name="cpu-a57" level="11" />
+		</threshold>
+		<threshold trigger="120" clear="100">
+			<mitigation name="cpu-a57" level="14" />
 		</threshold>
 	</configuration>
 </thermanager>


### PR DESCRIPTION
thermal-config claims to be reading emmc_therm, but that's impossible.
emmc_therm and msm_therm both give invalid values, however pm8994_tz
can be used with Sony's values directly, so this is probably what
is actually used by thermal-engine.

This thermanager config was heavily modified to take this into account.
It also splits the CPUs into their respective clusters.

Signed-off-by: Adam Farden adam@farden.cz
